### PR TITLE
Update homepage in gemspec

### DIFF
--- a/claide-plugins.gemspec
+++ b/claide-plugins.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
                          This plugin adds the "plugins" subcommand to a binary so that you can list
                          all plugins (registered in the reference JSON hosted at CocoaPods/cocoapods-plugins)
                        DESC
-  spec.homepage      = 'https://github.com/cocoapods/claide-plugins'
+  spec.homepage      = 'https://github.com/dbgrandi/claide-plugins'
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
The former https://github.com/cocoapods/claide-plugins returns 404 now.